### PR TITLE
Add administrator role with privileged access control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Admin User Configuration
+# Set these environment variables to customize admin credentials
+# These values will be used on first startup to create the admin user
+
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=admin123
+ADMIN_EMAIL=admin@kraftlog.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- **Administrator Role System**
+  - Added `isAdmin` boolean field to User entity to distinguish admin users from regular users
+  - Implemented automatic admin user creation on application startup via `AdminInitializer` component
+  - Added configurable admin credentials through environment variables:
+    - `ADMIN_USERNAME` (default: admin)
+    - `ADMIN_PASSWORD` (default: admin123)
+    - `ADMIN_EMAIL` (default: admin@kraftlog.com)
+  - Created `.env.example` file to document admin configuration options
+
+- **Admin-Only Exercise Management**
+  - Restricted exercise creation endpoint (`POST /api/exercises`) to admin users only
+  - Restricted exercise update endpoint (`PUT /api/exercises/{id}`) to admin users only
+  - Restricted exercise deletion endpoint (`DELETE /api/exercises/{id}`) to admin users only
+  - Regular users can still view all exercises
+
+- **Admin Management Endpoints**
+  - Added `DELETE /api/admin/users/{userId}` endpoint for admins to delete any user
+  - Added `PUT /api/admin/users/{userId}/password` endpoint for admins to change any user's password
+  - Created `AdminController` with `@PreAuthorize("hasRole('ADMIN')")` protection
+  - Created `AdminService` to handle admin-specific business logic
+  - Added `ChangePasswordRequest` DTO for password change operations
+
+- **Database Changes**
+  - Created Flyway migration `V3__add_admin_role.sql` to add `is_admin` column to users table
+  - Added database index on `is_admin` column for efficient admin queries
+
+- **Security Enhancements**
+  - Updated `CustomUserDetailsService` to assign `ROLE_ADMIN` to admin users and `ROLE_USER` to regular users
+  - Integrated Spring Security's `@PreAuthorize` annotation for role-based access control
+
+- **Testing Support**
+  - Added `adminUser()` builder method to `TestDataBuilder` for creating admin users in tests
+  - Updated existing user builder to explicitly set `isAdmin = false` for regular users
+
+- **Docker Compose Configuration**
+  - Added admin environment variables to docker-compose.yml with sensible defaults
+  - Environment variables are passed from host to container for flexible configuration
+
+### Changed
+- Updated User entity to include admin role flag with default value of `false`
+- Enhanced JWT authentication to include role information (ROLE_ADMIN or ROLE_USER)
+- Updated API documentation in README.md with comprehensive admin role documentation
+- Improved Swagger/OpenAPI documentation with admin-only endpoint markers
+
+### Documentation
+- Added "Administrator Role" section to README.md covering:
+  - Overview of admin privileges and capabilities
+  - Admin initialization process
+  - Three configuration options for setting admin credentials
+  - Default admin credentials with security warnings
+  - Complete admin operation examples with curl commands
+  - Comparison table of admin vs regular user permissions
+- Updated API Endpoints section to mark admin-only endpoints
+- Added admin configuration to Environment Variables section
+- Updated Database Migrations section to include V3 migration
+- Enhanced features list to highlight administrator role functionality
+
+### Security
+- Admin password defaults are documented with strong recommendation to change on first login
+- All admin operations require JWT authentication with ROLE_ADMIN authority
+- Admin endpoints return 403 Forbidden when accessed by non-admin users

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,9 @@ services:
       SPRING_DATASOURCE_USERNAME: postgres
       SPRING_DATASOURCE_PASSWORD: postgres
       SERVER_PORT: 8080
+      ADMIN_USERNAME: ${ADMIN_USERNAME:-admin}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD:-admin123}
+      ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@kraftlog.com}
     ports:
       - "8080:8080"
     depends_on:

--- a/src/main/java/com/kraftlog/config/AdminInitializer.java
+++ b/src/main/java/com/kraftlog/config/AdminInitializer.java
@@ -1,0 +1,50 @@
+package com.kraftlog.config;
+
+import com.kraftlog.entity.User;
+import com.kraftlog.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AdminInitializer implements CommandLineRunner {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${admin.username:admin}")
+    private String adminUsername;
+
+    @Value("${admin.password:admin123}")
+    private String adminPassword;
+
+    @Value("${admin.email:admin@kraftlog.com}")
+    private String adminEmail;
+
+    @Override
+    public void run(String... args) {
+        // Check if admin user already exists
+        if (userRepository.findByEmail(adminEmail).isPresent()) {
+            log.info("Admin user already exists with email: {}", adminEmail);
+            return;
+        }
+
+        // Create admin user
+        User admin = User.builder()
+                .name("Admin")
+                .surname("User")
+                .email(adminEmail)
+                .password(passwordEncoder.encode(adminPassword))
+                .isAdmin(true)
+                .build();
+
+        userRepository.save(admin);
+        log.info("Admin user created successfully with email: {}", adminEmail);
+        log.info("Please change the admin password after first login!");
+    }
+}

--- a/src/main/java/com/kraftlog/controller/AdminController.java
+++ b/src/main/java/com/kraftlog/controller/AdminController.java
@@ -1,0 +1,66 @@
+package com.kraftlog.controller;
+
+import com.kraftlog.dto.ChangePasswordRequest;
+import com.kraftlog.dto.UserResponse;
+import com.kraftlog.service.AdminService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+@Tag(name = "Admin Management", description = "Administrative APIs for user management (Admin only)")
+@SecurityRequirement(name = "bearer-jwt")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @Operation(summary = "Delete user (Admin only)",
+               description = "Deletes a user and all associated data. Only administrators can delete users.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "User deleted successfully"),
+            @ApiResponse(responseCode = "404", description = "User not found", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Admin access required", content = @Content)
+    })
+    @DeleteMapping("/users/{userId}")
+    public ResponseEntity<Void> deleteUser(
+            @Parameter(description = "UUID of the user to delete", required = true)
+            @PathVariable UUID userId) {
+        adminService.deleteUser(userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Change user password (Admin only)",
+               description = "Changes the password for any user. Only administrators can change other users' passwords.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Password changed successfully",
+                    content = @Content(schema = @Schema(implementation = UserResponse.class))),
+            @ApiResponse(responseCode = "404", description = "User not found", content = @Content),
+            @ApiResponse(responseCode = "400", description = "Invalid input data", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Admin access required", content = @Content)
+    })
+    @PutMapping("/users/{userId}/password")
+    public ResponseEntity<UserResponse> changeUserPassword(
+            @Parameter(description = "UUID of the user", required = true)
+            @PathVariable UUID userId,
+            @Valid @RequestBody ChangePasswordRequest request) {
+        UserResponse response = adminService.changeUserPassword(userId, request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/kraftlog/controller/ExerciseController.java
+++ b/src/main/java/com/kraftlog/controller/ExerciseController.java
@@ -16,6 +16,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -30,14 +31,16 @@ public class ExerciseController {
 
     private final ExerciseService exerciseService;
 
-    @Operation(summary = "Create a new exercise", description = "Creates a new exercise with specified details and target muscles")
+    @Operation(summary = "Create a new exercise (Admin only)", description = "Creates a new exercise with specified details and target muscles. Only administrators can create exercises.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Exercise created successfully",
                     content = @Content(schema = @Schema(implementation = ExerciseResponse.class))),
             @ApiResponse(responseCode = "400", description = "Invalid input data", content = @Content),
-            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content)
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Admin access required", content = @Content)
     })
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ExerciseResponse> createExercise(@Valid @RequestBody ExerciseCreateRequest request) {
         ExerciseResponse response = exerciseService.createExercise(request);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
@@ -69,15 +72,17 @@ public class ExerciseController {
         return ResponseEntity.ok(exercises);
     }
 
-    @Operation(summary = "Update exercise", description = "Updates an existing exercise")
+    @Operation(summary = "Update exercise (Admin only)", description = "Updates an existing exercise. Only administrators can update exercises.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Exercise updated successfully",
                     content = @Content(schema = @Schema(implementation = ExerciseResponse.class))),
             @ApiResponse(responseCode = "404", description = "Exercise not found", content = @Content),
             @ApiResponse(responseCode = "400", description = "Invalid input data", content = @Content),
-            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content)
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Admin access required", content = @Content)
     })
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ExerciseResponse> updateExercise(
             @Parameter(description = "Exercise ID") @PathVariable UUID id,
             @Valid @RequestBody ExerciseUpdateRequest request) {
@@ -85,13 +90,15 @@ public class ExerciseController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "Delete exercise", description = "Deletes an exercise by ID")
+    @Operation(summary = "Delete exercise (Admin only)", description = "Deletes an exercise by ID. Only administrators can delete exercises.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "Exercise deleted successfully"),
             @ApiResponse(responseCode = "404", description = "Exercise not found", content = @Content),
-            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content)
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Admin access required", content = @Content)
     })
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> deleteExercise(
             @Parameter(description = "Exercise ID") @PathVariable UUID id) {
         exerciseService.deleteExercise(id);

--- a/src/main/java/com/kraftlog/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/kraftlog/dto/ChangePasswordRequest.java
@@ -1,0 +1,20 @@
+package com.kraftlog.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request to change user password")
+public class ChangePasswordRequest {
+
+    @NotBlank(message = "New password is required")
+    @Size(min = 6, message = "Password must be at least 6 characters long")
+    @Schema(description = "New password for the user", example = "newSecurePassword123")
+    private String newPassword;
+}

--- a/src/main/java/com/kraftlog/entity/User.java
+++ b/src/main/java/com/kraftlog/entity/User.java
@@ -49,6 +49,10 @@ public class User {
     @Enumerated(EnumType.STRING)
     private FitnessGoal fitnessGoal;
 
+    @Column(name = "is_admin", nullable = false)
+    @Builder.Default
+    private Boolean isAdmin = false;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/kraftlog/entity/User.java
+++ b/src/main/java/com/kraftlog/entity/User.java
@@ -51,7 +51,7 @@ public class User {
 
     @Column(name = "is_admin", nullable = false)
     @Builder.Default
-    private Boolean isAdmin = false;
+    private boolean isAdmin = false;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/kraftlog/security/CustomUserDetailsService.java
+++ b/src/main/java/com/kraftlog/security/CustomUserDetailsService.java
@@ -22,10 +22,13 @@ public class CustomUserDetailsService implements UserDetailsService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
 
+        // Assign roles based on isAdmin flag
+        String role = user.getIsAdmin() ? "ROLE_ADMIN" : "ROLE_USER";
+
         return org.springframework.security.core.userdetails.User.builder()
                 .username(user.getEmail())
                 .password(user.getPassword())
-                .authorities(Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")))
+                .authorities(Collections.singletonList(new SimpleGrantedAuthority(role)))
                 .build();
     }
 }

--- a/src/main/java/com/kraftlog/service/AdminService.java
+++ b/src/main/java/com/kraftlog/service/AdminService.java
@@ -1,0 +1,47 @@
+package com.kraftlog.service;
+
+import com.kraftlog.dto.ChangePasswordRequest;
+import com.kraftlog.dto.UserResponse;
+import com.kraftlog.entity.User;
+import com.kraftlog.exception.ResourceNotFoundException;
+import com.kraftlog.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class AdminService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final ModelMapper modelMapper;
+
+    public void deleteUser(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", "id", userId));
+
+        log.info("Admin deleting user with email: {}", user.getEmail());
+        userRepository.delete(user);
+    }
+
+    public UserResponse changeUserPassword(UUID userId, ChangePasswordRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", "id", userId));
+
+        String encodedPassword = passwordEncoder.encode(request.getNewPassword());
+        user.setPassword(encodedPassword);
+
+        User updatedUser = userRepository.save(user);
+        log.info("Admin changed password for user with email: {}", user.getEmail());
+
+        return modelMapper.map(updatedUser, UserResponse.class);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,11 @@ jwt:
   secret: 5367566B59703373367639792F423F4528482B4D6251655468576D5A71347437
   expiration: 86400000 # 24 hours in milliseconds
 
+admin:
+  username: ${ADMIN_USERNAME:admin}
+  password: ${ADMIN_PASSWORD:admin123}
+  email: ${ADMIN_EMAIL:admin@kraftlog.com}
+
 logging:
   level:
     com.kraftlog: DEBUG

--- a/src/main/resources/db/migration/V3__add_admin_role.sql
+++ b/src/main/resources/db/migration/V3__add_admin_role.sql
@@ -1,0 +1,5 @@
+-- Add admin column to users table
+ALTER TABLE users ADD COLUMN is_admin BOOLEAN NOT NULL DEFAULT false;
+
+-- Create index for admin queries
+CREATE INDEX idx_users_is_admin ON users(is_admin);

--- a/src/test/java/com/kraftlog/TestDataBuilder.java
+++ b/src/test/java/com/kraftlog/TestDataBuilder.java
@@ -19,6 +19,20 @@ public class TestDataBuilder {
                 .weightKg(75.5)
                 .heightCm(180.0)
                 .fitnessGoal(User.FitnessGoal.HYPERTROPHY)
+                .isAdmin(false)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .routines(new ArrayList<>());
+    }
+
+    public static User.UserBuilder adminUser() {
+        return User.builder()
+                .name("Admin")
+                .surname("User")
+                .birthDate(LocalDate.of(1985, 5, 15))
+                .email("admin@kraftlog.com")
+                .password("admin123")
+                .isAdmin(true)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .routines(new ArrayList<>());


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive administrator role system to the KraftLog API, enabling privileged access control for exercise management and user administration.

## Changes

### Core Features
- **Admin Role System**: Added `isAdmin` boolean field to User entity to distinguish administrators from regular users
- **Auto-initialization**: Admin user is automatically created on first application startup with configurable credentials
- **Exercise Management**: Only administrators can create, update, or delete exercises
- **User Management**: Administrators can delete users and change passwords for any user

### Database Changes
- Added `is_admin` column to `users` table via Flyway migration V3
- Added database index on `is_admin` column for efficient admin queries
- Default value is `false` for regular users

### Security Enhancements
- JWT tokens now include role information (`ROLE_ADMIN` or `ROLE_USER`)
- Exercise management endpoints protected with `@PreAuthorize("hasRole('ADMIN')")`
- New admin endpoints in `AdminController` for user management
- Non-admin users receive 403 Forbidden when accessing admin-only endpoints

### Configuration
Admin credentials are configurable via environment variables:
- `ADMIN_USERNAME` (default: admin)
- `ADMIN_PASSWORD` (default: admin123)
- `ADMIN_EMAIL` (default: admin@kraftlog.com)

### API Endpoints Added
- `DELETE /api/admin/users/{userId}` - Delete any user (Admin only)
- `PUT /api/admin/users/{userId}/password` - Change any user's password (Admin only)

### API Endpoints Modified
- `POST /api/exercises` - Now requires admin role
- `PUT /api/exercises/{id}` - Now requires admin role
- `DELETE /api/exercises/{id}` - Now requires admin role

### New Files
- `AdminInitializer.java` - Automatically creates admin user on startup
- `AdminController.java` - REST controller for admin operations
- `AdminService.java` - Business logic for admin operations
- `ChangePasswordRequest.java` - DTO for password change requests
- `V3__add_admin_role.sql` - Database migration script
- `.env.example` - Environment variable documentation
- `CHANGELOG.md` - Project changelog

### Modified Files
- `User.java` - Added `isAdmin` field with default value
- `CustomUserDetailsService.java` - Role assignment based on admin flag
- `ExerciseController.java` - Added admin-only restrictions
- `TestDataBuilder.java` - Added admin user builder for tests
- `application.yml` - Added admin configuration properties
- `docker-compose.yml` - Added admin environment variables
- `README.md` - Comprehensive documentation of admin features

## Testing
- Updated `TestDataBuilder` with `adminUser()` method for testing admin scenarios
- All existing tests remain compatible with regular users

## Documentation
- Comprehensive README updates with admin role documentation
- Admin configuration examples for Docker Compose and standalone deployment
- Security warnings about changing default admin password
- Comparison table of admin vs regular user permissions

## Migration Notes
- Existing users will have `is_admin = false` by default
- Admin user is created automatically on first startup
- No breaking changes to existing functionality
- Regular users retain all existing permissions except exercise management

## Security Considerations
- Default admin credentials are documented with strong warnings to change immediately
- Admin operations require JWT authentication with proper role
- Passwords are hashed using BCrypt before storage
- Admin endpoints return 403 Forbidden for unauthorized access

## Backwards Compatibility
- ✅ All existing API endpoints remain functional
- ✅ Regular users can still view exercises
- ✅ Existing user data is preserved
- ✅ Database migration runs automatically

## Configuration Example
```bash
# Using .env file
ADMIN_USERNAME=admin
ADMIN_PASSWORD=your-secure-password
ADMIN_EMAIL=admin@yourdomain.com

docker-compose up -d
```