### PR TITLE
fix: correct attestation step to use build output digest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,6 +62,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -78,5 +79,5 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.meta.outputs.digest }}
+          subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
## Summary
Fixes the Docker attestation error in the CI pipeline.

## Problem
The attestation step was failing with:
```
Error: One of subject-path or subject-digest must be provided
```

This was because the workflow was trying to use `steps.meta.outputs.digest` from the `docker/metadata-action`, but that action doesn't output a digest.

## Solution
- Added `id: build` to the "Build and push Docker image" step
- Changed the attestation step to use `steps.build.outputs.digest` from the `docker/build-push-action` which correctly provides the image digest after building and pushing

## Testing
This fix will be validated by the CI pipeline run triggered by this PR.