### PR TITLE
fix: add attestations write permission for artifact attestation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,6 +22,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
Adds the required `attestations: write` permission to fix the attestation error in CI.

## Problem
After fixing the digest reference in PR #6, the attestation step now fails with:
```
Error: Failed to persist attestation: Resource not accessible by integration
```

This occurs because the workflow lacks the necessary permission to create attestations.

## Solution
Added `attestations: write` to the job permissions in the workflow file.

## Testing
This fix will be validated by the CI pipeline run triggered by this PR.